### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "bfiessinger/aos-for-gutenberg",
+    "description": "AOS Animations for the WordPress Gutenberg Editor",
+    "keywords": [
+        "aos",
+        "animations",
+        "gutenberg",
+        "wordpress",
+        "wordpress-plugin"
+    ],
+    "type": "wordpress-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Bastian Fießinger"
+        }
+    ],
+    "require": {
+        "php": ">=5.6"
+    }
+}


### PR DESCRIPTION
We found your plugin and it works well! Thanks for that!

We use composer to manage our PHP dependencies. Our WordPress installations are build on roots/bedrock, so we would like to include your plugin in our composer.json file. To use your repository via composer, a composer.json file has to be added to the root of this repository. I added the required file, so we can use composer to install your plugin. Please check the provided information in this file and add it to the repository. :)

We tried looking for this plugin on other places like packagist or wpackagist, but we did not find it there. Adding this composer file will be sufficient for everyone to start installing your plugin via composer.

Thanks for your work on this plugin!