### PR TITLE
Fix: undefined global post fatal error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -132,6 +132,9 @@ class aos {
 	function enqueue_aos_script() {
 
 		global $post;
+		
+		if ( ! $post ) return;
+		
 		$blocks_parsed = parse_blocks( $post->post_content );
 
 		$this->check_inner_blocks( $blocks_parsed );


### PR DESCRIPTION
On our search page (domain.com?s=word) we got the error: `undefined $post`. Adding a check fixes the error. It seemed like the error happened before our custom code was run. Our block was outside of the wordpress loop in the header of the page. I don't think we can fix it any other way.